### PR TITLE
feat(syslog) - Add the ability to send logs to a remote syslog server.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,15 @@ FROM fabric8/fluentd:0.14.0.pre.1
 
 MAINTAINER Jimmi Dyson <jimmidyson@gmail.com>
 
-ENTRYPOINT ["/start-fluentd"]
-
-ENV ELASTICSEARCH_HOST es-logging.default.svc
-
 RUN yum install -y gcc-c++
 
 RUN scl enable rh-ruby22 'gem install fluent-plugin-kubernetes_metadata_filter \
-                                      fluent-plugin-elasticsearch' && \
+                                      fluent-plugin-elasticsearch \
+                                      fluent-plugin-remote_syslog' && \
     scl enable rh-ruby22 'gem cleanup fluentd'
 
-ADD start-fluentd /start-fluentd
+RUN mkdir /etc/fluent
+COPY fluent.conf /etc/fluent/fluent.conf
+COPY start-fluentd /start-fluentd
+
+ENTRYPOINT ["/start-fluentd"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ variables:
 * `ELASTICSEARCH_SCHEME` - `http` or `https` (default: `http`)
 * `ELASTICSEARCH_USER` - user to connect with
 * `ELASTICSEARCH_PASSWORD` - password to connect with
+
+* `SYSLOG_HOST` - the syslog host to send data to (no default)
+* `SYSLOG_PORT` - the syslog port to send data to (no default)
+
+If you need to specify multiple syslog servers you can do -
+* `SYSLOG_HOST_1`
+* `SYSLOG_PORT_1`
+* `SYSLOG_HOST_2`
+* `SYSLOG_PORT_2`
+
 * `FLUENTD_FLUSH_INTERVAL` - how often to flush fluentd data
 (default: `10s`)
 * `FLUENTD_FLUSH_THREADS` - number of threads to use to flush

--- a/fluent.conf
+++ b/fluent.conf
@@ -53,7 +53,7 @@
 # in the /var/log/containers directory which includes the pod name and the Kubernetes
 # container name:
 #
-#    synthetic-logger-0.25lps-pod_default_synth-lgr-997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b.log 
+#    synthetic-logger-0.25lps-pod_default_synth-lgr-997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b.log
 #    ->
 #    /var/lib/docker/containers/997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b/997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b-json.log
 #
@@ -99,33 +99,3 @@
 # fluentd plugin but requires secrets to be enabled in the fluent pod. This is a
 # problem yet to be solved as secrets are not usable in static pods which the fluentd
 # pod must be until a per-node controller is available in Kubernetes.
-
-<source>
-  type tail
-  path /var/log/containers/*.log
-  pos_file /var/log/es-containers.log.pos
-  time_format %Y-%m-%dT%H:%M:%S.%N
-  tag kubernetes.*
-  format json
-  read_from_head true
-  keep_time_key true
-</source>
-
-<filter kubernetes.**>
-  type kubernetes_metadata
-</filter>
-
-<match **>
-  type elasticsearch
-  log_level info
-  include_tag_key true
-  host "#{ENV['ES_HOST']}"
-  port "#{ENV['ES_PORT']}"
-  logstash_format true
-  flush_interval 5s
-  # Never wait longer than 5 minutes between retries.
-  max_retry_wait 60
-  # Disable the limit on the number of retries (retry forever).
-  disable_retry_limit
-  time_key time
-</match>

--- a/start-fluentd
+++ b/start-fluentd
@@ -1,9 +1,4 @@
 #!/bin/sh
-
-ELASTICSEARCH_HOST=${ELASTICSEARCH_HOST:-es-logging.default.svc}
-ELASTICSEARCH_PORT=${ELASTICSEARCH_PORT:-9200}
-ELASTICSEARCH_SCHEME=${ELASTICSEARCH_SCHEME:-http}
-
 FLUENTD_FLUSH_INTERVAL=${FLUENTD_FLUSH_INTERVAL:-10s}
 FLUENTD_FLUSH_THREADS=${FLUENTD_FLUSH_THREADS:-1}
 FLUENTD_RETRY_LIMIT=${FLUENTD_RETRY_LIMIT:-10}
@@ -16,32 +11,36 @@ FLUENTD_BUFFER_TYPE=${FLUENTD_BUFFER_TYPE:-memory}
 FLUENTD_BUFFER_PATH=${FLUENTD_BUFFER_PATH:-/var/fluentd/buffer}
 FLUENTD_LOGSTASH_FORMAT=${FLUENTD_LOGSTASH_FORMAT:-true}
 
-mkdir /etc/fluent
-
-cat << 'EOF' > /etc/fluent/fluent.conf
-<source>
-  type tail
-  path /var/log/containers/*.log
-  pos_file /var/log/es-containers.log.pos
-  time_format %Y-%m-%dT%H:%M:%S.%N
-  tag kubernetes.*
-  format json
-  read_from_head true
-  keep_time_key true
-</source>
-
-<filter kubernetes.**>
-  type kubernetes_metadata
-</filter>
-
-<match **>
-  type elasticsearch
-  log_level info
-  include_tag_key true
-  time_key time
+cat << EOF >> /etc/fluent/fluent.conf
+  <source>
+    type tail
+    path /var/log/containers/*.log
+    pos_file /var/log/es-containers.log.pos
+    time_format %Y-%m-%dT%H:%M:%S.%N
+    tag kubernetes.*
+    format json
+    read_from_head true
+    keep_time_key true
+  </source>
+  <filter kubernetes.**>
+    type kubernetes_metadata
+  </filter>
+  <match **>
+  @type copy
 EOF
 
+if [ -n "$ELASTICSEARCH_HOST" ]
+  then
+  echo "Starting fluentd with elastic search configuration!"
+  ELASTICSEARCH_PORT=${ELASTICSEARCH_PORT:-9200}
+  ELASTICSEARCH_SCHEME=${ELASTICSEARCH_SCHEME:-http}
+
 cat << EOF >> /etc/fluent/fluent.conf
+<store>
+  @type elasticsearch
+  log_level warn
+  include_tag_key true
+  time_key time
   host ${ELASTICSEARCH_HOST}
   port ${ELASTICSEARCH_PORT}
   scheme ${ELASTICSEARCH_SCHEME}
@@ -59,8 +58,40 @@ cat << EOF >> /etc/fluent/fluent.conf
   num_threads ${FLUENTD_FLUSH_THREADS}
   logstash_format ${FLUENTD_LOGSTASH_FORMAT}
 EOF
+fi
 
-cat << 'EOF' >> /etc/fluent/fluent.conf
+NUM=$(env | grep -oE '^(SYSLOG_HOST_\d*)' | wc -l)
+for ((i=1; i<=$NUM; i++)) do
+host=$(eval "echo \$SYSLOG_HOST_$i")
+port=$(eval "echo \$SYSLOG_PORT_$i")
+if [ -n "$host" ]
+then
+echo "Starting fluentd with syslog configuration! -- $host:$port"
+cat << EOF >> /etc/fluent/fluent.conf
+<store>
+  @type remote_syslog
+  host $host
+  port $port
+  log_level warn
+</store>
+EOF
+fi
+done
+
+if [ -n "$SYSLOG_HOST" ]
+then
+echo "Starting fluentd with syslog configuration! -- $SYSLOG_HOST:$SYSLOG_PORT"
+cat << EOF >> /etc/fluent/fluent.conf
+<store>
+  @type remote_syslog
+  host $SYSLOG_HOST
+  port $SYSLOG_PORT
+  log_level warn
+</store>
+EOF
+fi
+
+cat << EOF >> /etc/fluent/fluent.conf
 </match>
 EOF
 


### PR DESCRIPTION
This adds the ability to have fluentd send data to a remote syslog server like papertrail. All you need to do is set `SYSLOG_HOST` and `SYSLOG_PORT`. I also updated the `start-fluentd` script to check for `ELASTICSEARCH_SERVICE` and `SYSLOG_HOST`. If neither are set it will exit and print a message saying that you should set the configuration for one. 
