### PR TITLE
Fix ERROR: string-scrub requires Ruby version <= 2.0.0, >= 1.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ENV ELASTICSEARCH_HOST es-logging.default.svc
 
 RUN yum install -y gcc-c++
 
-RUN scl enable rh-ruby22 'gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 0.18.0' && \
+RUN scl enable rh-ruby22 'gem install --no-document string-scrub -v 0.0.5' && \
+    scl enable rh-ruby22 'gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 0.18.0' && \
     scl enable rh-ruby22 'gem install --no-document fluent-plugin-elasticsearch -v 1.4.0' && \
     scl enable rh-ruby22 'gem cleanup fluentd'
 


### PR DESCRIPTION
There is a new release of the string-scrub gem today which causing the docker build to fail.
As a quick fix I am just using the older version of it.

For more info visit:
https://rubygems.org/gems/string-scrub/versions/0.1.0
