### PR TITLE
Update fluentd to 0.14.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fabric8/fluentd:0.14.6
+FROM fabric8/fluentd:0.14.8
 
 MAINTAINER Jimmi Dyson <jimmidyson@gmail.com>
 


### PR DESCRIPTION
There are important changes in 0.14.7, namely options to rotate fluentd's own logs, compression and a fix for https://github.com/fluent/fluentd/issues/1229

Using 0.14.8 because it is the latest, with another minor fix.
