### PR TITLE
Update ES plugin to 1.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV ELASTICSEARCH_HOST es-logging.default.svc
 RUN touch /var/lib/rpm/* && yum install -y gcc-c++ && yum clean all
 
 RUN scl enable rh-ruby23 'gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 0.26.2' && \
-    scl enable rh-ruby23 'gem install --no-document fluent-plugin-elasticsearch -v 1.9.1' && \
+    scl enable rh-ruby23 'gem install --no-document fluent-plugin-elasticsearch -v 1.9.2' && \
     scl enable rh-ruby23 'gem install --no-document fluent-plugin-prometheus -v 0.2.1' && \
     scl enable rh-ruby23 'gem cleanup fluentd'
 


### PR DESCRIPTION
elasticsearch_dynamic is busted with 0.14.X, where X>0.

ES 1.9.2 fixes it with https://github.com/uken/fluent-plugin-elasticsearch/pull/224

As far as I can tell, this is the last blocker for me (us) to move away from fluentd 0.14.0.pre.1.

Perhaps, at some point, 0.14.8 could be replaced with 0.14.10, but this is already good enough.