### PR TITLE
Update fluent-plugin-elasticsearch to 1.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV ELASTICSEARCH_HOST es-logging.default.svc
 RUN touch /var/lib/rpm/* && yum install -y gcc-c++ && yum clean all
 
 RUN scl enable rh-ruby23 'gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 0.26.2' && \
-    scl enable rh-ruby23 'gem install --no-document fluent-plugin-elasticsearch -v 1.9.2' && \
+    scl enable rh-ruby23 'gem install --no-document fluent-plugin-elasticsearch -v 1.9.5' && \
     scl enable rh-ruby23 'gem install --no-document fluent-plugin-prometheus -v 0.2.1' && \
     scl enable rh-ruby23 'gem cleanup fluentd'
 


### PR DESCRIPTION
With Elasticsearch >= 5.3, REST requests without a Content-Type will generate a
warning log : Content type detection for rest requests is deprecated.

This warning has been fixed in the latests fluent-plugin-elasticsearch
versions (>= 1.9.4).